### PR TITLE
Flush Sentry on stream end, so logging can be waited for on exit...

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -76,6 +76,12 @@ export default class SentryTransport extends TransportStream {
     return callback();
   }
 
+  end(...args: any[]) {
+    Sentry.flush().then(() => {
+      super.end(...args)
+    })
+  }
+
   public get sentry() {
     return Sentry;
   }


### PR DESCRIPTION
 ...as described in Winston readme.

https://github.com/winstonjs/winston#awaiting-logs-to-be-written-in-winston