### PR TITLE
Add user to sentry scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,13 @@ If `info.tags` is an object, it will be sent as [Sentry Tags](https://docs.sentr
 logger.error("some error", { tags: { tag1: "yo", tag2: "123" } });
 ```
 
-Additional properties of `info` are sent as [Sentry Extra Context](https://docs.sentry.io/enriching-error-data/context/?platform=javascript#extra-context). 
+If `info.user` is an object, it will be sent as [Sentry User](https://docs.sentry.io/platforms/javascript/#capturing-the-user).
+
+```js
+logger.error("some error", { user: { username: "somebody", id: "123" } });
+```
+
+Additional properties of `info` are sent as [Sentry Extra Context](https://docs.sentry.io/enriching-error-data/context/?platform=javascript#extra-context).
 
 ```js
 logger.error("some error", { whatever: "is sent as extra" });

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -42,7 +42,7 @@ export default class SentryTransport extends TransportStream {
 
     if (this.silent) return callback();
 
-    const { message, level: winstonLevel, tags, ...meta } = info;
+    const { message, level: winstonLevel, tags, user, ...meta } = info;
 
     const sentryLevel = (this.levelsMap as any)[winstonLevel];
 
@@ -53,8 +53,9 @@ export default class SentryTransport extends TransportStream {
 
       scope.setExtras(meta);
 
-      // TODO: add user details
-      // scope.setUser({ id: '4711' }); // id, email, username, ip_address
+      if (user !== undefined && this.isObject(user)) {
+        scope.setUser(user);
+      }
 
       // TODO: add fingerprints
       // scope.setFingerprint(['{{ default }}', path]); // fingerprint should be an array


### PR DESCRIPTION
Hi hi, I noticed that the user wasn't being added to the sentry scope, and I think handling it like tags (namely, passing in a `user` object through the `info`) would make sense. It would also allow this library to stay unopinionated about what that `user` should look like.

## Features

* added `user` handling to `info` arg
* updated docs to reflect this

I wasn't sure how to write a test for this, but I've been testing it manually and I'm seeing the user show up in sentry.