### PR TITLE
Derive original level from map with symbol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,12 @@
       "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
       "dev": true
     },
+    "@types/triple-beam": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
+      "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==",
+      "dev": true
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston-transport-sentry-node",
   "description": "@sentry/node transport for the winston v3 logger",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Andrew Avdeev <andrewww.avdeev@gmail.com>",
   "keywords": [
     "logger",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@sentry/node": "^6.1.0",
+    "triple-beam": "^1.3.0",
     "winston": "^3.3.3",
     "winston-transport": "^4.4.0"
   },
@@ -43,6 +44,7 @@
     "@types/chai": "^4.2.4",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.7.5",
+    "@types/triple-beam": "^1.3.2",
     "@typescript-eslint/eslint-plugin": "^2.3.0",
     "@typescript-eslint/parser": "^2.3.0",
     "chai": "^4.2.0",

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/node';
 import TransportStream = require("winston-transport");
+import { LEVEL } from 'triple-beam';
 
 const DEFAULT_LEVELS_MAP: SeverityOptions = {
   silly: Sentry.Severity.Debug,
@@ -50,7 +51,8 @@ export default class SentryTransport extends TransportStream {
 
     if (this.silent) return callback();
 
-    const { message, level: winstonLevel, tags, user, ...meta } = info;
+    const { message, level, tags, user, ...meta } = info;
+    const winstonLevel = info[LEVEL];
 
     const sentryLevel = (this.levelsMap as any)[winstonLevel];
 

--- a/test/format.ts
+++ b/test/format.ts
@@ -33,4 +33,28 @@ describe("SentryTransport", () => {
     });
     logger.info("...");
   });
+
+  it("should use the level derived from the symbol", (done) => {
+    const transport = new SentryTransport({
+      sentry: {
+        dsn: "https://something@localhost:443/123",
+        beforeSend(evt) {
+          expect(evt.level).to.equal("warning");
+          done();
+          return evt;
+        },
+      },
+      // Formatter which may change the level, like a `colorize`.
+      format: Winston.format((info) => {
+        info.level = "foo";
+        return info;
+      })(),
+      level: "info",
+    });
+
+    const logger = Winston.createLogger({
+      transports: [transport],
+    });
+    logger.warn("...");
+  })
 });


### PR DESCRIPTION
I am using this project with Backstage.io to write messages from the Winston logger to Sentry. The Backstage project includes a Logger which uses Winston's `colorize` formatter. Unfortunately, this formatter mutates the `info.level` property to set the colour - for example: `warn` becomes `"[32mwarn[39m"`.

The result is that all events are sent to Sentry at the default `info` level.

This change updates the transport to use the level defined by the symbol `LEVEL` from `winston/triple-beam`. This level is not changed, and the correct level is logged to Sentry.