### PR TITLE
Add option to skip Sentry initialization

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -14,6 +14,7 @@ const DEFAULT_LEVELS_MAP: SeverityOptions = {
 export interface SentryTransportOptions extends TransportStream.TransportStreamOptions {
   sentry?: Sentry.NodeOptions;
   levelsMap?: SeverityOptions;
+  skipSentryInit?: Boolean;
 }
 
 interface SeverityOptions {
@@ -41,7 +42,10 @@ export default class SentryTransport extends TransportStream {
 
     this.levelsMap = this.setLevelsMap(opts && opts.levelsMap);
     this.silent = opts && opts.silent || false;
-    Sentry.init(SentryTransport.withDefaults(opts && opts.sentry || {}));
+    
+    if (!opts || !opts.skipSentryInit) {
+      Sentry.init(SentryTransport.withDefaults(opts && opts.sentry || {}));
+    }
   }
 
   public log(info: any, callback: () => void) {


### PR DESCRIPTION
Sentry may be initialized already at another place in the application. In that case it's better not to initialize it again, otherwise events get sent twice.

I'm open for discussion whether this is the right way or how we could solve that issue otherwise. 