### PR TITLE
fix: return this on end()

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -100,6 +100,7 @@ export default class SentryTransport extends TransportStream {
     Sentry.flush().then(() => {
       super.end(...args);
     });
+    return this;
   }
 
   public get sentry() {


### PR DESCRIPTION
Hello 👋 
According to the [nodejs doc](https://nodejs.org/api/stream.html#writableendchunk-encoding-callback), the `end` method should return `this`.

Fixes #28 