### PR TITLE
Fix blindly forwarded stack

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -26,7 +26,7 @@ class ExtendedError extends Error {
     super(info.message);
 
     this.name = info.name || "Error";
-    if (info.stack) {
+    if (info.stack && typeof info.stack === "string") {
       this.stack = info.stack;
     }
   }


### PR DESCRIPTION
Hello,

I've had some problems with a `stack` property being present in my logging object (I'm using Nestjs + Nest-Winston), which made Sentry throw going through your library because you forward it like it's an error stack, but in my case it was an array, and down the line the Sentry library is expecting a string and performs a `.split('\n')` on it.

That's why I'm suggesting this fix which might hopefully prevent a lot of hair pulling in the future for people who are unfortunate like me.