### PR TITLE
Find the error in the info object

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -98,7 +98,8 @@ export default class SentryTransport extends TransportStream {
     // Capturing Errors / Exceptions
     if (SentryTransport.shouldLogException(sentryLevel)) {
       const error =
-        message instanceof Error ? message : new ExtendedError(info);
+        Object.values(info).find((value) => value instanceof Error) ??
+        new ExtendedError(info);
       Sentry.captureException(error, { tags });
 
       return callback();


### PR DESCRIPTION
Errors are often logged with an error message, and the error itself is passed as part of the info object.
This results in all the string messages having the same stack trace in Sentry (which is the stack of `winston-transport-sentry-node`).

This change looks for the error in the parameters passed, so that we capture the actual error.