### PR TITLE
Allowing fatal exceptions to be emitted at the sentry fatal level

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -100,7 +100,7 @@ export default class SentryTransport extends TransportStream {
       const error =
         Object.values(info).find((value) => value instanceof Error) ??
         new ExtendedError(info);
-      Sentry.captureException(error, { tags });
+      Sentry.captureException(error, { tags, level: sentryLevel });
 
       return callback();
     }


### PR DESCRIPTION
Currently, any winston logs that are at the error or fatal level always are getting emitted at the Sentry "error" level. This means that logger.log('fatal', 'some message') is only getting logged at the error level (assuming sentry level mapping for 'fatal' exists when configured).

This change allows emission at the fatal level so the library can support fatal level sentry errors as well.

**Testing**

> npm run build
> npm run lint
> npm run test

all succeed